### PR TITLE
Add custom gadi config for nfcore/scrnaseq

### DIFF
--- a/templates/nf-core/scrnaseq/gadi_custom.config
+++ b/templates/nf-core/scrnaseq/gadi_custom.config
@@ -66,9 +66,15 @@ process {
         time = { 1.h * task.attempt }
     }
 
-    withName: /ANNDATAR_CONVERT|CELLBENDER_REMOVEBACKGROUND/ {
+    withName: ANNDATAR_CONVERT {
         cpus = { 4 * task.attempt }
         memory = { 16.GB * task.attempt }  
         time = { 4.h * task.attempt }
+    }
+
+    withName: CELLBENDER_REMOVEBACKGROUND {
+        cpus = { 4 * task.attempt }
+        memory = { 16.GB * task.attempt }  
+        time = { 4.h * task.attempt * 3 }
     }
 }

--- a/templates/nf-core/scrnaseq/gadi_custom.config
+++ b/templates/nf-core/scrnaseq/gadi_custom.config
@@ -1,0 +1,74 @@
+// Set gadi parameters
+// NCI has special install of Nextflow. See: https://opus.nci.org.au/display/DAE/Nextflow
+
+params {
+    gadi_account = System.getenv("PROJECT")
+    gadi_storage = "scratch/${System.getenv('PROJECT')}"
+    gadi_user = System.getenv("USER")
+    singularityCacheDir = ''
+    timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
+}
+
+// Autodetect relevant Singularity env variables 
+singularity {
+    enabled = true
+    autoMounts = true
+    autoCleanUp = true
+    cacheDir = params.singularityCacheDir
+        ? params.singularityCacheDir
+        : "/scratch/${params.gadi_account}/${params.gadi_user}/.nextflow/singularity"
+}
+
+// Submit up to 300 concurrent jobs (Gadi exec max)
+// pollInterval and queueStatInterval of every 30 seconds
+// submitRateLimit of 20 per minute
+executor {
+    queueSize = 300
+    pollInterval = '30 sec'
+    queueStatInterval = '30 sec'
+    submitRateLimit = '20 min'
+}
+
+// Set default resources for each process 
+// See https://www.nextflow.io/docs/latest/config.html?highlight=withname#scope-process 
+process {
+    module = 'singularity'
+    cache = 'lenient'
+    executor = 'pbspro'
+    project = "${params.gadi_account}"
+    storage = "${params.gadi_storage}"
+    queue = { task.memory < 128.GB ? 'normalbw' : (task.memory < 190.GB ? 'normal' : 'hugemem') }
+}
+
+// Write custom trace file with outputs required for SU calculation
+trace {
+    enabled = true
+    overwrite = false
+    file = "${params.outdir}/run_info/gadi-nf-core-trace-${params.timestamp}.txt"
+    fields = 'name,status,exit,duration,realtime,cpus,%cpu,memory,%mem,rss'
+}
+
+process {
+
+    // Module configs: cpu and mem are configured for normalbw fairshare %
+    // Processes labeled with process_medium request too many resources by default.
+    // These include FASTQC, ANNDATAR_CONVERT, MTX_TO_H5AD, CELLBENDER_REMOVEBACKGROUND
+
+    withName: CELLRANGER_COUNT { 
+        cpus = { 16 * task.attempt }
+        memory = { 72.GB * task.attempt }
+		time = { 12.h * task.attempt }
+	}
+
+    withName: /FASTQC|MTX_TO_H5AD|CONCAT_H5AD|MULTIQC/ { 
+        cpus = { 2 * task.attempt }
+        memory = { 8.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+
+    withName: /ANNDATAR_CONVERT|CELLBENDER_REMOVEBACKGROUND/ {
+        cpus = { 4 * task.attempt }
+        memory = { 16.GB * task.attempt }  
+        time = { 4.h * task.attempt }
+    }
+}

--- a/templates/nf-core/scrnaseq/gadi_custom.config
+++ b/templates/nf-core/scrnaseq/gadi_custom.config
@@ -67,7 +67,8 @@ process {
     }
 
     withName: ANNDATAR_CONVERT {
-        cpus = { 4 * task.attempt }
+        errorStrategy = "retry"
+        cpus = 4 
         memory = { 16.GB * task.attempt }  
         time = { 4.h * task.attempt }
     }


### PR DESCRIPTION
Gadi config works on larger mouse data (15~20k cells per sample) for benchmarking SU usage.  Not optimised yet.